### PR TITLE
feat(moodle): Implement session refresh for Moodle API integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,9 @@ from src.core.notification.processor import NotificationProcessor
 from src.core.service_locator import ServiceLocator
 from src.core.services import initialize_services
 from src.core.utils.retry import with_retry
+from src.infrastructure.http.request_manager import request_manager
 from src.infrastructure.logging.setup import setup_logging
+from src.services.moodle.api import MoodleAPI
 from src.services.moodle.notification_handler import MoodleNotificationHandler
 from src.ui.cli.screen import animate_logo, logo_lines
 
@@ -87,9 +89,23 @@ def calculate_sleep_time(consecutive_errors: int, base_interval: int) -> float:
 def run_main_loop(config, moodle_handler, notification_processor) -> None:
     """Run the main application loop."""
     consecutive_errors = 0
+    # Session refresh interval in hours
+    session_refresh_interval = 24.0
+    
+    # Get Moodle API instance from service locator
+    locator = ServiceLocator()
+    moodle_api = locator.get("moodle_api", MoodleAPI)
 
     while True:
         try:
+            # Check if session needs to be refreshed (older than 24 hours)
+            if request_manager.session_age_hours >= session_refresh_interval:
+                logging.info(f"Session is {request_manager.session_age_hours:.2f} hours old. Refreshing...")
+                if moodle_api.refresh_session():
+                    logging.info("Session successfully refreshed")
+                else:
+                    logging.error("Failed to refresh session. Continuing with existing session.")
+            
             success = fetch_and_process(moodle_handler, notification_processor)
             if success:
                 consecutive_errors = 0

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def run_main_loop(config, moodle_handler, notification_processor) -> None:
     consecutive_errors = 0
     # Session refresh interval in hours
     session_refresh_interval = 24.0
-    
+
     # Get Moodle API instance from service locator
     locator = ServiceLocator()
     moodle_api = locator.get("moodle_api", MoodleAPI)
@@ -100,12 +100,16 @@ def run_main_loop(config, moodle_handler, notification_processor) -> None:
         try:
             # Check if session needs to be refreshed (older than 24 hours)
             if request_manager.session_age_hours >= session_refresh_interval:
-                logging.info(f"Session is {request_manager.session_age_hours:.2f} hours old. Refreshing...")
+                logging.info(
+                    f"Session is {request_manager.session_age_hours:.2f} hours old. Refreshing..."
+                )
                 if moodle_api.refresh_session():
                     logging.info("Session successfully refreshed")
                 else:
-                    logging.error("Failed to refresh session. Continuing with existing session.")
-            
+                    logging.error(
+                        "Failed to refresh session. Continuing with existing session."
+                    )
+
             success = fetch_and_process(moodle_handler, notification_processor)
             if success:
                 consecutive_errors = 0

--- a/src/infrastructure/http/request_manager.py
+++ b/src/infrastructure/http/request_manager.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional
 
 import requests
@@ -10,6 +11,7 @@ class RequestManager:
 
     _instance: Optional["RequestManager"] = None
     _session: Optional[requests.Session] = None
+    _session_created_at: float = 0
 
     def __new__(cls) -> "RequestManager":
         if cls._instance is None:
@@ -19,6 +21,10 @@ class RequestManager:
 
     def _setup_session(self) -> None:
         """Setup the global session with default headers."""
+        # Close existing session if it exists
+        if self._session is not None:
+            self._session.close()
+            
         self._session = requests.Session()
         self._session.headers.update(
             {
@@ -26,6 +32,7 @@ class RequestManager:
                 "Content-Type": "application/x-www-form-urlencoded",
             }
         )
+        self._session_created_at = time.time()
 
     @property
     def session(self) -> requests.Session:
@@ -41,6 +48,17 @@ class RequestManager:
             self._setup_session()
         assert self._session is not None
         self._session.headers.update(headers)
+        
+    def reset_session(self) -> None:
+        """Reset the session completely, creating a new one."""
+        self._setup_session()
+        
+    @property
+    def session_age_hours(self) -> float:
+        """Return the age of the current session in hours."""
+        if self._session_created_at == 0:
+            return 0
+        return (time.time() - self._session_created_at) / 3600
 
 
 # Global instance

--- a/src/infrastructure/http/request_manager.py
+++ b/src/infrastructure/http/request_manager.py
@@ -24,7 +24,7 @@ class RequestManager:
         # Close existing session if it exists
         if self._session is not None:
             self._session.close()
-            
+
         self._session = requests.Session()
         self._session.headers.update(
             {
@@ -48,11 +48,11 @@ class RequestManager:
             self._setup_session()
         assert self._session is not None
         self._session.headers.update(headers)
-        
+
     def reset_session(self) -> None:
         """Reset the session completely, creating a new one."""
         self._setup_session()
-        
+
     @property
     def session_age_hours(self) -> float:
         """Return the age of the current session in hours."""

--- a/src/services/moodle/api.py
+++ b/src/services/moodle/api.py
@@ -87,7 +87,7 @@ class MoodleAPI:
 
         # Update our session reference
         self.session = request_manager.session
-        
+
         # Re-login with stored credentials
         self.token = None
         return self.login(self._username, self._password)

--- a/src/services/moodle/api.py
+++ b/src/services/moodle/api.py
@@ -87,12 +87,7 @@ class MoodleAPI:
 
         # Update our session reference
         self.session = request_manager.session
-        request_manager.update_headers(
-            {
-                "Content-Type": "application/x-www-form-urlencoded",
-            }
-        )
-
+        
         # Re-login with stored credentials
         self.token = None
         return self.login(self._username, self._password)

--- a/src/services/moodle/api.py
+++ b/src/services/moodle/api.py
@@ -31,15 +31,15 @@ class MoodleAPI:
                 "Content-Type": "application/x-www-form-urlencoded",
             }
         )
-        self.token = None
-        self.userid = None
-        self._username = None
-        self._password = None
+        self.token: Optional[str] = None
+        self.userid: Optional[int] = None
+        self._username: Optional[str] = None
+        self._password: Optional[str] = None
 
     def login(self, username: str, password: str) -> bool:
         """
         Logs in to the Moodle instance using the provided username and password.
-        
+
         Stores credentials securely for session refresh if successful.
         """
         if not username:
@@ -79,12 +79,12 @@ class MoodleAPI:
         if not self._username or not self._password:
             logger.error("Cannot refresh session: No stored credentials")
             return False
-            
+
         logger.info("Refreshing Moodle session...")
-        
+
         # Reset the request manager's session
         request_manager.reset_session()
-        
+
         # Update our session reference
         self.session = request_manager.session
         request_manager.update_headers(
@@ -92,7 +92,7 @@ class MoodleAPI:
                 "Content-Type": "application/x-www-form-urlencoded",
             }
         )
-        
+
         # Re-login with stored credentials
         self.token = None
         return self.login(self._username, self._password)


### PR DESCRIPTION
Added functionality to refresh the Moodle session automatically if it is older than 24 hours. This ensures that the application maintains a valid session without manual intervention. The session age is tracked, and credentials are securely stored for re-authentication during the refresh process.

- Introduced session management in RequestManager
- Enhanced MoodleAPI with session refresh capability
- Integrated session checks in the main application loop

## Summary by Sourcery

Implements automatic session refresh for the Moodle API integration to ensure the application maintains a valid session without manual intervention. The session is refreshed if it is older than 24 hours.