### PR TITLE
docs(README): Add DeepWiki badge for enhanced project visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/EvickaStudio/Moodle-Mate/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/EvickaStudio/Moodle-Mate"></a>
   <a href="https://github.com/EvickaStudio/Moodle-Mate/pulls"><img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/EvickaStudio/Moodle-Mate"></a>
   <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/EvickaStudio/Moodle-Mate">
+  <a href="https://deepwiki.com/EvickaStudio/Moodle-Mate"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 ## What is Moodle Mate?


### PR DESCRIPTION
Included a badge linking to DeepWiki in the README to provide users with an additional resource for asking questions and accessing information about the project. This enhances the documentation and user engagement.

## Summary by Sourcery

Documentation:
- Add DeepWiki badge to README linking to the project’s DeepWiki page for improved visibility and user engagement.