### PR TITLE
fix: make config loader more robust

### DIFF
--- a/src/core/config/loader.py
+++ b/src/core/config/loader.py
@@ -69,11 +69,17 @@ class Config:
 
     def get_config_int(self, section: str, key: str, default: int = 0) -> int:
         value = self.get_config(section, key)
-        return int(value) if value is not None else default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
 
     def get_config_float(self, section: str, key: str, default: float = 0.0) -> float:
         value = self.get_config(section, key)
-        return float(value) if value is not None else default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
 
     def _get_config(self, section: str, key: str, default: Any = None) -> Any:
         """Get configuration value with fallback to default."""


### PR DESCRIPTION
## Summary
- handle missing configuration file by using an empty parser
- expose simple accessors for configuration values
- trim docstrings and switch to f-string logging in config loader

## Testing
- `PYTHONPATH=src pytest tests/utils/test_config.py -q`
- `PYTHONPATH=src pytest tests/notification/test_notification_processor.py tests/notification/test_notification_sender.py tests/notification/test_notification_summarizer.py -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `PYTHONPATH=. pytest tests/notification/test_notification_processor.py tests/notification/test_notification_sender.py tests/notification/test_notification_summarizer.py -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_689cc34d326c8323b9013389d58e41ab

## Summary by Sourcery

Enhance robustness of the configuration loader by falling back to an empty parser when the config file is absent, logging a warning instead of raising an error, and exposing simple typed accessor methods while preserving backwards compatibility.

New Features:
- Add get_config, get_config_boolean, get_config_int, and get_config_float helper methods for typed configuration access

Bug Fixes:
- Handle missing configuration file gracefully by using an empty parser and logging a warning instead of raising FileNotFoundError

Enhancements:
- Alias the internal parser to the existing config attribute for backward compatibility
- Trim docstrings and switch to f-string logging in the config loader