### PR TITLE
test: close critical test gaps and align local CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,8 @@ jobs:
     - name: Sync dependencies
       run: uv sync --extra dev --frozen
 
-    - name: Ruff lint (no fixes)
-      run: uv run ruff check --output-format=concise .
-
-    - name: Ruff format check
-      run: uv run ruff format --check .
+    - name: CI lint checks
+      run: make ci-lint
 
     - name: Minimize uv cache
       if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run tests
         env:
           PYTHONPATH: src
-        run: uv run pytest -q
+        run: make ci-test

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ concerns, you can use a locally hosted model (e.g. with
    make install
    make run
    make test
+   make ci-local
    make help
    ```
 

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,0 +1,124 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from moodlemate.app import MoodleMateApp
+
+
+def _build_settings(
+    *,
+    web_enabled: bool = False,
+    auth_secret: str | None = "secret",
+    health_enabled: bool = False,
+    failure_threshold: int | None = None,
+    target_provider: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        web=SimpleNamespace(
+            enabled=web_enabled,
+            auth_secret=auth_secret,
+            host="127.0.0.1",
+            port=9095,
+        ),
+        notification=SimpleNamespace(fetch_interval=60, max_retries=5),
+        health=SimpleNamespace(
+            enabled=health_enabled,
+            heartbeat_interval=None,
+            failure_alert_threshold=failure_threshold,
+            target_provider=target_provider,
+        ),
+    )
+
+
+def _build_app(settings: SimpleNamespace) -> MoodleMateApp:
+    return MoodleMateApp(
+        settings=settings,
+        notification_processor=Mock(providers=[]),
+        moodle_handler=Mock(),
+        moodle_api=Mock(),
+        state_manager=Mock(),
+    )
+
+
+def test_run_saves_state_on_keyboard_interrupt():
+    settings = _build_settings()
+    app = _build_app(settings)
+    app._main_loop = Mock(side_effect=KeyboardInterrupt)
+
+    app.run()
+
+    app.state_manager.maybe_save_state.assert_called_once_with(force=True)
+
+
+def test_fetch_and_process_notifications_marks_processed_ids():
+    settings = _build_settings()
+    app = _build_app(settings)
+    app.moodle_handler.fetch_newest_notification.return_value = [
+        {"id": 101, "subject": "A", "fullmessagehtml": "<p>A</p>", "useridfrom": 1},
+        {"id": 102, "subject": "B", "fullmessagehtml": "<p>B</p>", "useridfrom": 2},
+    ]
+
+    result = app._fetch_and_process_notifications()
+
+    assert result is True
+    assert app.notification_processor.process.call_count == 2
+    app.moodle_handler.mark_notification_processed.assert_any_call(101)
+    app.moodle_handler.mark_notification_processed.assert_any_call(102)
+
+
+def test_handle_error_triggers_failure_alert_at_threshold():
+    settings = _build_settings(
+        health_enabled=True,
+        failure_threshold=2,
+    )
+    app = _build_app(settings)
+    app._send_failure_alert = Mock()
+
+    consecutive_errors, sleep_seconds = app._handle_error(1, RuntimeError("boom"))
+
+    assert consecutive_errors == 2
+    assert sleep_seconds == 60
+    app._send_failure_alert.assert_called_once()
+
+
+def test_send_health_notification_uses_target_provider():
+    settings = _build_settings(
+        health_enabled=True,
+        target_provider="discord",
+    )
+    app = _build_app(settings)
+    discord = Mock()
+    discord.provider_name = "discord"
+    discord.send.return_value = True
+    app.notification_processor.providers = [discord]
+
+    app._send_health_notification("subject", "message")
+
+    discord.send.assert_called_once_with("subject", "message")
+
+
+def test_check_and_refresh_session_calls_api_when_session_is_old(monkeypatch):
+    settings = _build_settings()
+    app = _build_app(settings)
+    app.moodle_api.refresh_session.return_value = True
+
+    monkeypatch.setattr(
+        "moodlemate.app.request_manager.get_session_age_hours",
+        lambda _scope: 25.0,
+    )
+
+    app._check_and_refresh_session(interval=24.0)
+
+    app.moodle_api.refresh_session.assert_called_once()
+
+
+def test_send_heartbeat_if_due_sends_notification():
+    settings = _build_settings(health_enabled=True, target_provider="discord")
+    settings.health.heartbeat_interval = 1
+    app = _build_app(settings)
+    app._send_health_notification = Mock()
+    app._last_heartbeat_sent = time.time() - (2 * 3600)
+
+    app._send_heartbeat_if_due()
+
+    app._send_health_notification.assert_called_once()

--- a/tests/infrastructure/test_logging_setup.py
+++ b/tests/infrastructure/test_logging_setup.py
@@ -1,0 +1,49 @@
+import logging
+from contextlib import suppress
+from logging.handlers import RotatingFileHandler
+
+from moodlemate.infrastructure.logging.setup import ColoredFormatter, setup_logging
+
+
+def _reset_root_logger() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        with suppress(Exception):
+            handler.close()
+
+
+def test_setup_logging_creates_handlers_and_log_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _reset_root_logger()
+
+    setup_logging("DEBUG")
+
+    root = logging.getLogger()
+    assert (tmp_path / "logs").exists()
+    assert any(isinstance(h, RotatingFileHandler) for h in root.handlers)
+    assert any(isinstance(h, logging.StreamHandler) for h in root.handlers)
+    assert logging.getLogger("urllib3").level == logging.WARNING
+    assert logging.getLogger("requests").level == logging.WARNING
+
+    _reset_root_logger()
+
+
+def test_colored_formatter_applies_level_color_and_restores_levelname():
+    formatter = ColoredFormatter("%(levelname)s %(name)s %(message)s")
+    record = logging.LogRecord(
+        name="moodlemate.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    rendered = formatter.format(record)
+
+    assert "\033[32m" in rendered
+    assert "\033[35m" in rendered
+    assert "hello" in rendered
+    assert record.levelname == "INFO"

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -1,0 +1,151 @@
+import argparse
+import runpy
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import moodlemate.main as main_module
+
+
+@pytest.fixture
+def fake_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        moodle=SimpleNamespace(
+            url="https://moodle.example.edu",
+            username="alice",
+            password="supersecret",
+        ),
+        ai=SimpleNamespace(
+            enabled=False,
+            api_key="",
+            endpoint=None,
+            model="gpt-5-nano",
+            system_prompt="summary",
+            temperature=0.7,
+            max_tokens=150,
+        ),
+        notification=SimpleNamespace(
+            connect_timeout=10.0,
+            read_timeout=30.0,
+            retry_total=3,
+            retry_backoff_factor=1.0,
+        ),
+        session_encryption_key="enc-key",
+    )
+
+
+def test_main_happy_path_initializes_and_runs(monkeypatch, fake_settings):
+    args = argparse.Namespace(test_notification=False)
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda _self: args)
+    monkeypatch.setattr(main_module, "setup_logging", Mock())
+    monkeypatch.setattr(main_module, "print_logo", Mock())
+    monkeypatch.setattr(main_module, "Settings", Mock(return_value=fake_settings))
+    init_run = Mock()
+    monkeypatch.setattr(main_module, "initialize_and_run_app", init_run)
+
+    main_module.main()
+
+    init_run.assert_called_once_with(fake_settings, args)
+
+
+def test_main_exits_when_settings_fail(monkeypatch):
+    args = argparse.Namespace(test_notification=False)
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda _self: args)
+    monkeypatch.setattr(main_module, "setup_logging", Mock())
+    monkeypatch.setattr(main_module, "print_logo", Mock())
+    monkeypatch.setattr(main_module, "Settings", Mock(side_effect=RuntimeError("bad")))
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+
+
+def test_main_exits_on_startup_failure(monkeypatch, fake_settings):
+    args = argparse.Namespace(test_notification=False)
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda _self: args)
+    monkeypatch.setattr(main_module, "setup_logging", Mock())
+    monkeypatch.setattr(main_module, "print_logo", Mock())
+    monkeypatch.setattr(main_module, "Settings", Mock(return_value=fake_settings))
+    monkeypatch.setattr(
+        main_module,
+        "initialize_and_run_app",
+        Mock(side_effect=RuntimeError("startup failed")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+
+
+def test_initialize_and_run_app_sends_test_notification(monkeypatch, fake_settings):
+    args = argparse.Namespace(test_notification=True)
+    app = Mock()
+    monkeypatch.setattr(main_module.request_manager, "configure", Mock())
+    monkeypatch.setattr(main_module, "StateManager", Mock(return_value=Mock()))
+    monkeypatch.setattr(main_module, "MoodleAPI", Mock(return_value=Mock()))
+    monkeypatch.setattr(main_module, "initialize_providers", Mock(return_value=[]))
+    monkeypatch.setattr(main_module, "NotificationProcessor", Mock(return_value=Mock()))
+    monkeypatch.setattr(
+        main_module,
+        "MoodleNotificationHandler",
+        Mock(return_value=Mock()),
+    )
+    monkeypatch.setattr(main_module, "MoodleMateApp", Mock(return_value=app))
+
+    main_module.initialize_and_run_app(fake_settings, args)
+
+    app.send_test_notification.assert_called_once()
+    app.run.assert_not_called()
+
+
+def test_initialize_and_run_app_runs_with_ai_enabled(monkeypatch, fake_settings):
+    args = argparse.Namespace(test_notification=False)
+    fake_settings.ai.enabled = True
+    fake_settings.ai.api_key = "sk-" + ("a" * 48)
+    fake_settings.ai.endpoint = "https://api.openai.example/v1"
+    state_manager = Mock()
+    moodle_api = Mock()
+    app = Mock()
+    gpt_instance = Mock()
+
+    monkeypatch.setattr(main_module.request_manager, "configure", Mock())
+    monkeypatch.setattr(main_module, "StateManager", Mock(return_value=state_manager))
+    monkeypatch.setattr(main_module, "MoodleAPI", Mock(return_value=moodle_api))
+    monkeypatch.setattr(main_module, "GPT", Mock(return_value=gpt_instance))
+    summarizer = Mock()
+    monkeypatch.setattr(
+        main_module,
+        "NotificationSummarizer",
+        Mock(return_value=summarizer),
+    )
+    monkeypatch.setattr(main_module, "initialize_providers", Mock(return_value=[]))
+    monkeypatch.setattr(main_module, "NotificationProcessor", Mock(return_value=Mock()))
+    monkeypatch.setattr(
+        main_module,
+        "MoodleNotificationHandler",
+        Mock(return_value=Mock()),
+    )
+    monkeypatch.setattr(main_module, "MoodleMateApp", Mock(return_value=app))
+
+    main_module.initialize_and_run_app(fake_settings, args)
+
+    assert gpt_instance.api_key == fake_settings.ai.api_key
+    assert gpt_instance.endpoint == fake_settings.ai.endpoint
+    app.run.assert_called_once()
+    app.send_test_notification.assert_not_called()
+
+
+def test_dunder_main_invokes_package_main(monkeypatch):
+    called = {"value": False}
+
+    def fake_main():
+        called["value"] = True
+
+    monkeypatch.setattr("moodlemate.main.main", fake_main)
+
+    runpy.run_module("moodlemate.__main__", run_name="__main__")
+
+    assert called["value"] is True

--- a/tests/moodle/test_api.py
+++ b/tests/moodle/test_api.py
@@ -1,0 +1,178 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from moodlemate.moodle import api as moodle_api_module
+from moodlemate.moodle.api import MoodleAPI
+
+
+@pytest.fixture
+def api(monkeypatch, tmp_path) -> MoodleAPI:
+    monkeypatch.setenv("MOODLE_SESSION_FILE", str(tmp_path / "moodle_session.json"))
+    return MoodleAPI(
+        url="https://moodle.example.edu",
+        username="alice",
+        password="password123",
+        session_encryption_key="unit-test-secret",
+    )
+
+
+def test_login_success_sets_token_and_saves_state(api: MoodleAPI, monkeypatch):
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"token": "abc123"}
+    api.session = Mock()
+    api.session.post.return_value = response
+    api._save_session_state = Mock()
+    monkeypatch.setattr(
+        moodle_api_module.rate_limiter_manager,
+        "is_allowed",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert api.login() is True
+    assert api.token == "abc123"
+    api._save_session_state.assert_called_once()
+
+
+def test_login_returns_false_when_api_returns_error(api: MoodleAPI, monkeypatch):
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"error": "Invalid login"}
+    api.session = Mock()
+    api.session.post.return_value = response
+    monkeypatch.setattr(
+        moodle_api_module.rate_limiter_manager,
+        "is_allowed",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert api.login() is False
+    assert api.token is None
+
+
+def test_login_raises_when_rate_limited(api: MoodleAPI, monkeypatch):
+    monkeypatch.setattr(
+        moodle_api_module.rate_limiter_manager,
+        "is_allowed",
+        lambda *_args, **_kwargs: False,
+    )
+
+    with pytest.raises(ValueError, match="Too many login attempts"):
+        api.login()
+
+
+def test_get_site_info_requires_token(api: MoodleAPI):
+    api.token = None
+    assert api.get_site_info() is None
+
+
+def test_refresh_session_resets_session_and_reauthenticates(
+    api: MoodleAPI, monkeypatch
+):
+    api.login = Mock(return_value=True)
+    api._clear_session_state = Mock()
+    reset_session = Mock()
+    fresh_session = Mock()
+    monkeypatch.setattr(
+        moodle_api_module.request_manager, "reset_session", reset_session
+    )
+    monkeypatch.setattr(
+        moodle_api_module.request_manager,
+        "get_session",
+        Mock(return_value=fresh_session),
+    )
+
+    assert api.refresh_session() is True
+    reset_session.assert_called_once_with("moodle")
+    api._clear_session_state.assert_called_once()
+    assert api.session is fresh_session
+    api.login.assert_called_once()
+
+
+def test_post_returns_none_when_rate_limited(api: MoodleAPI, monkeypatch):
+    api.token = "token"
+    monkeypatch.setattr(
+        moodle_api_module.rate_limiter_manager,
+        "is_allowed",
+        lambda *_args, **_kwargs: False,
+    )
+
+    assert api._post("message_popup_get_popup_notifications", user_id=1) is None
+
+
+def test_post_returns_response_payload(api: MoodleAPI, monkeypatch):
+    api.token = "token"
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"notifications": []}
+    api.session = Mock()
+    api.session.post.return_value = response
+    api._save_session_state = Mock()
+    monkeypatch.setattr(
+        moodle_api_module.rate_limiter_manager,
+        "is_allowed",
+        lambda *_args, **_kwargs: True,
+    )
+
+    result = api._post("message_popup_get_popup_notifications", user_id=1, limit=5)
+
+    assert result == {"notifications": []}
+    api._save_session_state.assert_called_once()
+
+
+def test_restore_session_state_loads_encrypted_payload(api: MoodleAPI):
+    assert api._session_fernet is not None
+    payload = {
+        "token": "restored-token",
+        "userid": 321,
+    }
+    encrypted = api._session_fernet.encrypt(json.dumps(payload).encode("utf-8")).decode(
+        "utf-8"
+    )
+    session_file = Path(api.session_state_file)
+    session_file.write_text(
+        json.dumps({"version": 1, "ciphertext": encrypted}),
+        encoding="utf-8",
+    )
+    api.token = None
+    api.userid = None
+
+    restored = api._restore_session_state()
+
+    assert restored is True
+    assert api.token == "restored-token"
+    assert api.userid == 321
+
+
+def test_clear_session_state_clears_memory_and_file(api: MoodleAPI, tmp_path):
+    cache_file = tmp_path / "session.json"
+    cache_file.write_text("{}", encoding="utf-8")
+    api.session_state_file = str(cache_file)
+    api.session = Mock()
+    api.session.cookies = Mock()
+    api.token = "token"
+    api.userid = 111
+
+    api._clear_session_state()
+
+    assert api.token is None
+    assert api.userid is None
+    api.session.cookies.clear.assert_called_once()
+    assert not cache_file.exists()
+
+
+def test_cipher_not_created_without_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOODLE_SESSION_FILE", str(tmp_path / "moodle_session.json"))
+    monkeypatch.delenv("MOODLEMATE_SESSION_ENCRYPTION_KEY", raising=False)
+
+    api = MoodleAPI(
+        url="https://moodle.example.edu",
+        username="alice",
+        password="password123",
+        session_encryption_key=None,
+    )
+
+    assert api._session_fernet is None

--- a/tests/moodle/test_notification_handler.py
+++ b/tests/moodle/test_notification_handler.py
@@ -1,0 +1,148 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from moodlemate.moodle.errors import MoodleConnectionError
+from moodlemate.moodle.notification_handler import MoodleNotificationHandler
+
+
+def _build_handler(last_notification_id: int | None = 10) -> MoodleNotificationHandler:
+    handler = MoodleNotificationHandler.__new__(MoodleNotificationHandler)
+    handler.settings = SimpleNamespace(
+        moodle=SimpleNamespace(initial_fetch_count=3),
+    )
+    handler.api = Mock()
+    handler.state_manager = Mock(last_notification_id=last_notification_id)
+    handler.last_notification_id = last_notification_id
+    handler.moodle_user_id = 42
+    handler.last_successful_connection = time.time()
+    handler.session_timeout = 3600
+    handler.max_reconnect_attempts = 3
+    handler.reconnect_delay = 0
+    return handler
+
+
+def test_init_logs_in_and_loads_user_id():
+    settings = SimpleNamespace(moodle=SimpleNamespace(initial_fetch_count=1))
+    api = Mock()
+    api.login.return_value = True
+    api.get_user_id.return_value = 123
+    state_manager = Mock(last_notification_id=55)
+
+    handler = MoodleNotificationHandler(settings, api, state_manager)
+
+    assert handler.moodle_user_id == 123
+    assert handler.last_notification_id == 55
+    api.login.assert_called_once()
+    api.get_user_id.assert_called_once()
+
+
+def test_fetch_latest_notification_returns_processed_notification():
+    handler = _build_handler()
+    handler._ensure_connection = Mock()
+    handler.api.get_popup_notifications.return_value = {
+        "notifications": [
+            {
+                "id": 99,
+                "useridfrom": 7,
+                "subject": "Update",
+                "fullmessagehtml": "<p>body</p>",
+            }
+        ]
+    }
+
+    result = handler.fetch_latest_notification()
+
+    assert result == {
+        "id": 99,
+        "useridfrom": 7,
+        "subject": "Update",
+        "fullmessagehtml": "<p>body</p>",
+    }
+
+
+def test_fetch_newest_notification_uses_initial_fetch_when_no_state():
+    handler = _build_handler(last_notification_id=None)
+    handler._handle_initial_fetch = Mock(return_value=[{"id": 1}])
+
+    result = handler.fetch_newest_notification()
+
+    assert result == [{"id": 1}]
+    handler._handle_initial_fetch.assert_called_once()
+
+
+def test_fetch_newest_notification_returns_none_when_latest_is_not_newer():
+    handler = _build_handler(last_notification_id=20)
+    handler.fetch_latest_notification = Mock(
+        return_value={
+            "id": 20,
+            "useridfrom": 1,
+            "subject": "Same",
+            "fullmessagehtml": "x",
+        }
+    )
+
+    assert handler.fetch_newest_notification() is None
+
+
+def test_mark_notification_processed_updates_state_manager():
+    handler = _build_handler(last_notification_id=2)
+
+    handler.mark_notification_processed(11)
+
+    assert handler.last_notification_id == 11
+    handler.state_manager.set_last_notification_id.assert_called_once_with(11)
+
+
+def test_handle_initial_fetch_processes_notifications_in_reverse_order():
+    handler = _build_handler(last_notification_id=None)
+    notifications = [
+        {"id": 1, "useridfrom": 1, "subject": "A", "fullmessagehtml": "A"},
+        {"id": 2, "useridfrom": 1, "subject": "B", "fullmessagehtml": "B"},
+        {"id": 3, "useridfrom": 1, "subject": "C", "fullmessagehtml": "C"},
+    ]
+    handler.fetch_notifications = Mock(return_value=notifications)
+    call_order: list[int] = []
+    handler._handle_new_notification = Mock(
+        side_effect=lambda *_args: call_order.append(_args[1])
+    )  # type: ignore[assignment]
+
+    result = handler._handle_initial_fetch()
+
+    assert result == notifications
+    assert call_order == [3, 2, 1]
+
+
+def test_fetch_notifications_raises_after_retries(monkeypatch):
+    handler = _build_handler()
+    handler._fetch_notifications = Mock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(
+        "moodlemate.moodle.notification_handler.time.sleep", lambda *_: None
+    )
+
+    with pytest.raises(MoodleConnectionError, match="Failed to fetch notifications"):
+        handler.fetch_notifications(limit=5)
+
+
+def test_user_id_from_accepts_list_payload():
+    handler = _build_handler()
+    handler._ensure_connection = Mock()
+    handler.api.core_user_get_users_by_field.return_value = [
+        {"id": "5", "fullname": "Alice", "profileimageurl": "https://img.local/u.png"}
+    ]
+
+    result = handler.user_id_from(5)
+
+    assert result == {
+        "id": 5,
+        "fullname": "Alice",
+        "profileimageurl": "https://img.local/u.png",
+    }
+
+
+def test_process_notification_returns_none_for_missing_fields():
+    handler = _build_handler()
+
+    assert handler._process_notification({"id": 1, "subject": "incomplete"}) is None

--- a/tests/moodle/test_notification_handler.py
+++ b/tests/moodle/test_notification_handler.py
@@ -63,6 +63,25 @@ def test_fetch_latest_notification_returns_processed_notification():
     }
 
 
+def test_ensure_connection_reconnects_when_session_is_expired():
+    handler = _build_handler()
+    handler.last_successful_connection = time.time() - handler.session_timeout - 5
+    handler._reconnect = Mock()
+
+    handler._ensure_connection()
+
+    handler._reconnect.assert_called_once()
+
+
+def test_ensure_connection_propagates_reconnect_failure_when_expired():
+    handler = _build_handler()
+    handler.last_successful_connection = time.time() - handler.session_timeout - 5
+    handler._reconnect = Mock(side_effect=MoodleConnectionError("reconnect failed"))
+
+    with pytest.raises(MoodleConnectionError, match="reconnect failed"):
+        handler._ensure_connection()
+
+
 def test_fetch_newest_notification_uses_initial_fetch_when_no_state():
     handler = _build_handler(last_notification_id=None)
     handler._handle_initial_fetch = Mock(return_value=[{"id": 1}])

--- a/tests/web/test_web_api.py
+++ b/tests/web/test_web_api.py
@@ -1,0 +1,179 @@
+import httpx
+import pytest
+
+from moodlemate.config import Settings
+from moodlemate.web.api import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, WebUI
+
+
+class DummyStateManager:
+    def __init__(self) -> None:
+        self.last_notification_id = 77
+        self._history = [
+            {
+                "id": 77,
+                "subject": "Hello",
+                "message": "Body",
+                "providers": ["discord"],
+                "timestamp": 1700000000,
+            }
+        ]
+
+    def get_history(self) -> list[dict]:
+        return list(self._history)
+
+
+class DummyAppInstance:
+    def __init__(self) -> None:
+        self.test_notifications_sent = 0
+
+    def send_test_notification(self) -> None:
+        self.test_notifications_sent += 1
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        _env_file=None,
+        moodle={
+            "url": "https://moodle.example.edu",
+            "username": "alice",
+            "password": "supersecret",
+            "initial_fetch_count": 2,
+        },
+        ai={"enabled": True, "api_key": "sk-" + ("a" * 48)},
+        web={"enabled": True, "host": "127.0.0.1", "port": 9095, "auth_secret": "pw"},
+        discord={"enabled": True, "webhook_url": "https://discord.example/webhook"},
+        pushbullet={"enabled": True, "api_key": "pb-secret"},
+        webhook_site={"enabled": True, "webhook_url": "https://webhook.site/test"},
+    )
+
+
+@pytest.fixture
+def webui(settings: Settings) -> tuple[WebUI, DummyAppInstance]:
+    state_manager = DummyStateManager()
+    app_instance = DummyAppInstance()
+    return WebUI(settings, state_manager, app_instance), app_instance
+
+
+@pytest.fixture
+async def client(webui: tuple[WebUI, DummyAppInstance]) -> httpx.AsyncClient:
+    ui, _ = webui
+    transport = httpx.ASGITransport(app=ui.get_app())
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+async def _login(client: httpx.AsyncClient, password: str = "pw") -> None:
+    await client.get("/login")
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token
+
+    response = await client.post(
+        "/api/login",
+        json={"password": password},
+        headers={CSRF_HEADER_NAME: csrf_token},
+    )
+    assert response.status_code == 200
+
+
+def _csrf_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert token
+    return {CSRF_HEADER_NAME: token}
+
+
+@pytest.mark.anyio
+async def test_protected_route_requires_authentication(client: httpx.AsyncClient):
+    response = await client.get("/api/status")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_login_requires_csrf_token(client: httpx.AsyncClient):
+    response = await client.post("/api/login", json={"password": "pw"})
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_authenticated_user_can_fetch_status_history_and_config(
+    client: httpx.AsyncClient,
+):
+    await _login(client)
+
+    status = await client.get("/api/status")
+    history = await client.get("/api/history")
+    config = await client.get("/api/config")
+
+    assert status.status_code == 200
+    assert status.json()["last_notification_id"] == 77
+    assert history.status_code == 200
+    assert len(history.json()) == 1
+    assert config.status_code == 200
+    config_payload = config.json()
+    assert config_payload["moodle"]["password"] == "********"
+    assert config_payload["ai"]["api_key"] == "********"
+    assert config_payload["discord"]["webhook_url"] == "********"
+
+
+@pytest.mark.anyio
+async def test_config_update_keeps_immutable_fields(
+    client: httpx.AsyncClient, settings: Settings
+):
+    await _login(client)
+    original_moodle_url = settings.moodle.url
+
+    response = await client.post(
+        "/api/config",
+        json={
+            "moodle": {"url": "https://evil.invalid"},
+            "notification": {"fetch_interval": 123},
+            "health": {"enabled": True, "target_provider": "discord"},
+        },
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert settings.moodle.url == original_moodle_url
+    assert settings.notification.fetch_interval == 123
+    assert settings.health.enabled is True
+    assert settings.health.target_provider == "discord"
+
+
+@pytest.mark.anyio
+async def test_test_notification_endpoint_triggers_app_instance(
+    client: httpx.AsyncClient, webui: tuple[WebUI, DummyAppInstance]
+):
+    _, app_instance = webui
+    await _login(client)
+
+    response = await client.post(
+        "/api/test-notification",
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert app_instance.test_notifications_sent == 1
+
+
+@pytest.mark.anyio
+async def test_logout_invalidates_session(client: httpx.AsyncClient):
+    await _login(client)
+    assert (await client.get("/api/status")).status_code == 200
+
+    response = await client.post("/api/logout", headers=_csrf_headers(client))
+    assert response.status_code == 200
+    assert (await client.get("/api/status")).status_code == 401
+
+
+def test_webui_refuses_to_start_without_auth_secret(settings: Settings):
+    settings.web.auth_secret = None
+    with pytest.raises(ValueError, match="requires 'web.auth_secret'"):
+        WebUI(settings, DummyStateManager(), DummyAppInstance())

--- a/tests/web/test_web_api.py
+++ b/tests/web/test_web_api.py
@@ -103,6 +103,25 @@ async def test_login_requires_csrf_token(client: httpx.AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_login_with_invalid_password_keeps_client_unauthenticated(
+    client: httpx.AsyncClient,
+):
+    await client.get("/login")
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token
+
+    login_response = await client.post(
+        "/api/login",
+        json={"password": "wrong-password"},
+        headers={CSRF_HEADER_NAME: csrf_token},
+    )
+    assert login_response.status_code == 401
+
+    status_response = await client.get("/api/status")
+    assert status_response.status_code == 401
+
+
+@pytest.mark.anyio
 async def test_authenticated_user_can_fetch_status_history_and_config(
     client: httpx.AsyncClient,
 ):


### PR DESCRIPTION
## Summary
- add high-impact runtime coverage for app, Moodle API/handler, and Web API flows
- add second-pass coverage for main entrypoint, __main__, and logging setup
- add CI-aligned local targets in Makefile (ci-local/ci-lint/ci-test) and wire workflows to use them

## Verification
- make check
- make test
- make ci-local
- pytest --cov=src/moodlemate --cov-report=term-missing

## Notes
- branch target: dev
- total coverage improved from 42% to 65%

## Summary by Sourcery

Add high-impact test coverage across core runtime flows and align local development commands with CI workflows.

Enhancements:
- Introduce CI-aligned Makefile targets for linting and testing and update GitHub workflows and README to use them.

Documentation:
- Document the ci-local Makefile target for running CI-equivalent checks locally.

Tests:
- Add web API tests covering authentication, CSRF protection, configuration management, and session handling.
- Add Moodle API tests for login, session persistence, rate limiting, and encrypted session state handling.
- Add main module tests covering startup flows, error handling, AI configuration, and __main__ entrypoint behavior.
- Add Moodle notification handler tests for initialization, notification fetching, retry behavior, and user resolution.
- Add core app tests for run loop behavior, notification processing, health checks, session refresh, and heartbeats.
- Add logging setup tests to validate handler configuration, log directory creation, and colored formatter behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds tests and reroutes CI commands through Makefile aliases; minimal production code impact beyond potential CI behavior differences if the new targets diverge from prior commands.
> 
> **Overview**
> Adds a substantial set of unit tests covering core runtime behaviors (`MoodleMateApp` loop/error handling, health notifications, session refresh), main entrypoints (`main()`/`__main__`), logging setup, Moodle API/session persistence & rate limiting, Moodle notification handling, and Web UI auth/CSRF/config redaction + immutability + logout/test-notification endpoints.
> 
> Refactors CI command execution to go through new Makefile targets (`ci-lint`, `ci-test`, `ci-local`, plus `format-check`/`test-ci`) and updates GitHub Actions workflows and the README to use these CI-aligned commands (including concise Ruff output in `lint-check`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2034e6f5c3374ffe8ae799f68d5798f00b2507a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->