### PR TITLE
fix(markdown): compact notification list spacing and cleanup

### DIFF
--- a/src/moodlemate/markdown/converter.py
+++ b/src/moodlemate/markdown/converter.py
@@ -1,11 +1,11 @@
+import logging
 import re
 
-# import logging
 from .turndown import MarkdownConverter
 
 TURNDOWN = MarkdownConverter({"headingStyle": "atx", "codeBlockStyle": "fenced"})
 
-# logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def convert(html_content: str) -> str:
@@ -19,24 +19,31 @@ def convert(html_content: str) -> str:
         str: The converted and cleaned content.
     """
     # logger.info(f"Original HTML content:\n{html_content}")
-    md_output = TURNDOWN.to_markdown(html_content)
-    # logger.info(f"Raw markdown output:\n{md_output}")
-    cleaned = clean_converted_text(md_output)
-    # logger.info(f"Final cleaned markdown:\n{cleaned}")
-    return cleaned
+    return apply_custom_rules(TURNDOWN.to_markdown(html_content))
 
 
-def clean_converted_text(text: str) -> str:
+# When turndown markdown conversion is not working as expected and malformes lines etc.
+# mdformat can be used to format the markdown to comply with commonmark spec. (currently not used)
+# def format_markdown(text: str) -> str:
+#     """
+#     Formats Markdown content with mdformat.
+#     """
+#     import mdformat
+#     return mdformat.text(text).strip()
+
+
+def apply_custom_rules(text: str) -> str:
     """
-    Cleans the converted text by applying regex replacements.
+    Applies a custom set of rules to the already converted markdown text.
     Makes the output Discord-embed safe.
 
     Args:
-        text (str): The text to be cleaned.
+        text (str): The markdowntext to be cleaned.
 
     Returns:
-        str: The cleaned text.
+        str: The cleaned markdown text.
     """
+
     # Remove navigation breadcrumbs
     text = re.sub(r"\[.*?\]\(.*?\)\s*»\s*", "", text)
 
@@ -79,4 +86,82 @@ def clean_converted_text(text: str) -> str:
     # Ensure there's no more than one blank line between paragraphs
     text = re.sub(r"\n\s*\n", "\n\n", text)
 
+    # Fix broken bold markers split across lines (seen in some Moodle messages).
+    text = re.sub(r"\*\*([^\n*]+@[^\n*]+)\n\*\*([^\n]+)", r"\1\n\2", text)
+    text = re.sub(r"(?m)^\*\*$", "", text)
+
+    # Convert "heading + spaced lines" blocks into compact bullet lists.
+    text = normalize_spaced_list_blocks(text)
+
+    # Ensure there are no blank lines between list items.
+    text = compact_list_item_spacing(text)
+
     return text
+
+
+def compact_list_item_spacing(text: str) -> str:
+    """Collapse blank lines between consecutive markdown list items."""
+    text = re.sub(r"(?m)^([*+-]\s.+)\n\n(?=[*+-]\s)", r"\1\n", text)
+    text = re.sub(r"(?m)^(\d+\.\s.+)\n\n(?=\d+\.\s)", r"\1\n", text)
+    return text
+
+
+def normalize_spaced_list_blocks(text: str) -> str:
+    """
+    Convert pseudo-lists into markdown bullet lists.
+
+    This targets patterns like:
+    "Was Dich erwartet:" + blank lines + short item lines.
+    """
+    lines = text.splitlines()
+    normalized: list[str] = []
+    idx = 0
+
+    while idx < len(lines):
+        line = lines[idx]
+        if not _is_list_intro_line(line):
+            normalized.append(line)
+            idx += 1
+            continue
+
+        item_idx = idx + 1
+        while item_idx < len(lines) and not lines[item_idx].strip():
+            item_idx += 1
+
+        items: list[str] = []
+        scan_idx = item_idx
+        while scan_idx < len(lines):
+            candidate = lines[scan_idx].strip()
+            if not _is_list_item_candidate(candidate):
+                break
+            items.append(candidate)
+            scan_idx += 1
+            if scan_idx < len(lines) and not lines[scan_idx].strip():
+                scan_idx += 1
+            else:
+                break
+
+        if len(items) < 2:
+            normalized.append(line)
+            idx += 1
+            continue
+
+        normalized.extend([line, ""])
+        normalized.extend(f"- {item}" for item in items)
+        idx = scan_idx
+        continue
+
+    return "\n".join(normalized)
+
+
+def _is_list_intro_line(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped) and stripped.endswith(":")
+
+
+def _is_list_item_candidate(line: str) -> bool:
+    return bool(line) and not (
+        line.startswith(("-", "*", "+"))
+        or len(line) > 90
+        or line.endswith((".", "!", "?", ":"))
+    )

--- a/src/moodlemate/markdown/converter.py
+++ b/src/moodlemate/markdown/converter.py
@@ -95,6 +95,8 @@ def apply_custom_rules(text: str) -> str:
 
     # Ensure there are no blank lines between list items.
     text = compact_list_item_spacing(text)
+    # Final pass to preserve compact paragraph spacing after all rewrites.
+    text = re.sub(r"\n{3,}", "\n\n", text)
 
     return text
 
@@ -130,6 +132,7 @@ def normalize_spaced_list_blocks(text: str) -> str:
 
         items: list[str] = []
         scan_idx = item_idx
+        consumed_separator = False
         while scan_idx < len(lines):
             candidate = lines[scan_idx].strip()
             if not _is_list_item_candidate(candidate):
@@ -138,7 +141,9 @@ def normalize_spaced_list_blocks(text: str) -> str:
             scan_idx += 1
             if scan_idx < len(lines) and not lines[scan_idx].strip():
                 scan_idx += 1
+                consumed_separator = True
             else:
+                consumed_separator = False
                 break
 
         if len(items) < 2:
@@ -148,6 +153,13 @@ def normalize_spaced_list_blocks(text: str) -> str:
 
         normalized.extend([line, ""])
         normalized.extend(f"- {item}" for item in items)
+        if (
+            consumed_separator
+            and scan_idx < len(lines)
+            and lines[scan_idx].strip()
+            and not _is_list_item_candidate(lines[scan_idx].strip())
+        ):
+            normalized.append("")
         idx = scan_idx
         continue
 

--- a/src/moodlemate/markdown/converter.py
+++ b/src/moodlemate/markdown/converter.py
@@ -38,7 +38,7 @@ def apply_custom_rules(text: str) -> str:
     Makes the output Discord-embed safe.
 
     Args:
-        text (str): The markdowntext to be cleaned.
+        text (str): The Markdown text to be cleaned.
 
     Returns:
         str: The cleaned markdown text.

--- a/tests/markdown/test_markdown_converter.py
+++ b/tests/markdown/test_markdown_converter.py
@@ -1,4 +1,4 @@
-from moodlemate.markdown.converter import clean_converted_text, convert
+from moodlemate.markdown.converter import apply_custom_rules, convert
 
 
 def test_convert_basic_html_to_markdown():
@@ -54,36 +54,59 @@ def test_convert_formatting():
     md_list = convert("<ul><li>Item 1</li><li>Item 2</li></ul>")
     assert "* Item 1" in md_list
     assert "* Item 2" in md_list
+    assert "\n\n* Item 2" not in md_list
 
 
 def test_cleaner_patterns():
-    """Test regex cleaning patterns in clean_converted_text."""
+    """Test regex cleaning patterns in apply_custom_rules."""
     # Navigation breadcrumbs
     text = "[Home](/) » [Course](/c) » Lesson"
-    assert clean_converted_text(text) == "Lesson"
+    assert apply_custom_rules(text) == "Lesson"
 
     # Images (should all be removed)
     images = "![alt](x.png) Some text [![x](y)](z) [](/img.jpg)"
-    assert clean_converted_text(images) == "Some text"
+    assert apply_custom_rules(images) == "Some text"
 
     # Forum management links
     forum_links = "Some content\n[Forum abbestellen]\nMore footer info"
-    assert clean_converted_text(forum_links) == "Some content"
+    assert apply_custom_rules(forum_links) == "Some content"
 
     forum_links_2 = "Discussion text\n[Diskussion im Forum zeigen]\nMore footer info"
-    assert clean_converted_text(forum_links_2) == "Discussion text"
+    assert apply_custom_rules(forum_links_2) == "Discussion text"
 
 
 def test_cleaner_whitespace():
     """Test whitespace and newline normalization."""
     # Multiple newlines
     text = "Line 1\n\n\n\nLine 2"
-    assert clean_converted_text(text) == "Line 1\n\nLine 2"
+    assert apply_custom_rules(text) == "Line 1\n\nLine 2"
 
     # Multiple spaces
     text = "Too    many      spaces"
-    assert clean_converted_text(text) == "Too many spaces"
+    assert apply_custom_rules(text) == "Too many spaces"
 
     # Trailing/leading whitespace
     text = "   \n   Surrounded   \n   "
-    assert clean_converted_text(text) == "Surrounded"
+    assert apply_custom_rules(text) == "Surrounded"
+
+
+def test_cleaner_normalizes_spaced_pseudo_list():
+    """Convert heading + spaced lines into compact markdown bullets."""
+    text = (
+        "Was Dich erwartet:\n\n"
+        "Individuelle Gruendungsberatung\n\n"
+        "Persoenliches Mentoring\n\n"
+        "Workshops, Events und Networking"
+    )
+    cleaned = apply_custom_rules(text)
+    assert "- Individuelle Gruendungsberatung" in cleaned
+    assert "- Persoenliches Mentoring" in cleaned
+    assert "- Workshops, Events und Networking" in cleaned
+
+
+def test_cleaner_fixes_split_bold_email():
+    """Remove broken bold markers split around an email line."""
+    text = "Sende alle Unterlagen an: **info@example.com\n**Weitere Infos hier."
+    cleaned = apply_custom_rules(text)
+    assert "**" not in cleaned
+    assert "info@example.com" in cleaned

--- a/tests/markdown/test_markdown_converter.py
+++ b/tests/markdown/test_markdown_converter.py
@@ -104,9 +104,42 @@ def test_cleaner_normalizes_spaced_pseudo_list():
     assert "- Workshops, Events und Networking" in cleaned
 
 
+def test_cleaner_compacts_raw_bullet_list_spacing():
+    """Collapse blank lines between bullet list items on raw markdown."""
+    text = "* Item 1\n\n* Item 2\n\n* Item 3"
+    cleaned = apply_custom_rules(text)
+    assert cleaned == "* Item 1\n* Item 2\n* Item 3"
+
+
+def test_cleaner_compacts_raw_numbered_list_spacing():
+    """Collapse blank lines between numbered list items on raw markdown."""
+    text = "1. Item 1\n\n2. Item 2\n\n3. Item 3"
+    cleaned = apply_custom_rules(text)
+    assert cleaned == "1. Item 1\n2. Item 2\n3. Item 3"
+
+
 def test_cleaner_fixes_split_bold_email():
     """Remove broken bold markers split around an email line."""
     text = "Sende alle Unterlagen an: **info@example.com\n**Weitere Infos hier."
     cleaned = apply_custom_rules(text)
     assert "**" not in cleaned
     assert "info@example.com" in cleaned
+
+
+def test_cleaner_preserves_non_email_multiline_bold():
+    """Do not alter multiline bold text when it is not an email split."""
+    text = "**Wichtiger Hinweis\n**Weitere Informationen folgen."
+    cleaned = apply_custom_rules(text)
+    assert cleaned == text
+
+
+def test_cleaner_fixes_multiple_split_bold_email_segments():
+    """Fix each split email-bold segment in the same text."""
+    text = (
+        "Kontakt A: **a@example.com\n**Infos A\n\n"
+        "Kontakt B: **b@example.com\n**Infos B"
+    )
+    cleaned = apply_custom_rules(text)
+    assert "**" not in cleaned
+    assert "a@example.com\nInfos A" in cleaned
+    assert "b@example.com\nInfos B" in cleaned

--- a/tests/markdown/test_markdown_converter.py
+++ b/tests/markdown/test_markdown_converter.py
@@ -136,8 +136,7 @@ def test_cleaner_preserves_non_email_multiline_bold():
 def test_cleaner_fixes_multiple_split_bold_email_segments():
     """Fix each split email-bold segment in the same text."""
     text = (
-        "Kontakt A: **a@example.com\n**Infos A\n\n"
-        "Kontakt B: **b@example.com\n**Infos B"
+        "Kontakt A: **a@example.com\n**Infos A\n\nKontakt B: **b@example.com\n**Infos B"
     )
     cleaned = apply_custom_rules(text)
     assert "**" not in cleaned

--- a/tests/markdown/test_markdown_converter.py
+++ b/tests/markdown/test_markdown_converter.py
@@ -142,3 +142,17 @@ def test_cleaner_fixes_multiple_split_bold_email_segments():
     assert "**" not in cleaned
     assert "a@example.com\nInfos A" in cleaned
     assert "b@example.com\nInfos B" in cleaned
+
+
+def test_cleaner_keeps_compact_spacing_after_bold_marker_removal():
+    """Avoid reintroducing extra blank lines after removing orphan bold markers."""
+    text = "Hello\n\n**\n\nWorld"
+    cleaned = apply_custom_rules(text)
+    assert cleaned == "Hello\n\nWorld"
+
+
+def test_cleaner_preserves_separator_after_converted_pseudo_list():
+    """Keep one blank line between converted list and following paragraph."""
+    text = "Was Dich erwartet:\n\nPunkt A\n\nPunkt B\n\nDanach folgt ein Absatz."
+    cleaned = apply_custom_rules(text)
+    assert "- Punkt A\n- Punkt B\n\nDanach folgt ein Absatz." in cleaned

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "moodle-mate"
-version = "2.2.4"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
This pull request enhances the Markdown conversion logic by introducing more robust post-processing rules to clean and normalize the output, particularly for Discord-embed safety and improved readability. It also refactors the code for clarity and updates the test suite to cover the new behaviors.

**Markdown conversion and cleaning improvements:**

* Replaces the old `clean_converted_text` function with a new `apply_custom_rules` function, which is now used in the main `convert` workflow to apply a comprehensive set of post-processing rules to the converted Markdown.
* Adds new normalization routines to:
  - Fix broken bold markers that are split across lines (e.g., emails in bold that break formatting).
  - Convert "heading + spaced lines" pseudo-lists into proper Markdown bullet lists for better structure.
  - Ensure there are no blank lines between consecutive list items, resulting in more compact lists.

**Code and test refactoring:**

* Refactors imports and logger setup for clarity, and documents the purpose of new and changed functions.
* Updates all tests to use `apply_custom_rules` instead of the removed `clean_converted_text`, and adds new tests for the pseudo-list normalization and bold marker fixes to ensure correctness. [[1]](diffhunk://#diff-e03da2d843854f317e00dca4583f0820add69baa0dcc54b2aabcb6c6d5b0d8d2L1-R1) [[2]](diffhunk://#diff-e03da2d843854f317e00dca4583f0820add69baa0dcc54b2aabcb6c6d5b0d8d2R57-R112)

## Summary by Sourcery

Improve Markdown conversion post-processing for cleaner, Discord-safe output and update tests accordingly.

Enhancements:
- Replace the previous cleaning function with a new apply_custom_rules pipeline in the Markdown conversion workflow.
- Introduce normalization helpers to compact list item spacing and convert heading-plus-lines pseudo-lists into proper bullet lists.
- Add regex handling to repair broken bold markers around email addresses and remove stray markers.
- Enable logger usage and clarify converter module structure and documentation.

Tests:
- Update existing Markdown converter tests to use apply_custom_rules instead of the removed clean_converted_text.
- Add tests covering pseudo-list normalization, list spacing compaction, and bold email marker fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-processing of converted Markdown via new regex/heuristic rules, which may alter user-visible notification content (especially around lists and bold text) in edge cases.
> 
> **Overview**
> Markdown conversion now routes through `apply_custom_rules` (replacing `clean_converted_text`) and extends the cleanup pipeline to **repair split bold markers around emails**, **convert “heading + spaced lines” blocks into bullet lists**, and **remove blank lines between list items** for more compact embeds.
> 
> Tests are updated/expanded to validate the new normalization behaviors, and `uv.lock` bumps the project version from `2.2.4` to `2.4.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa2ab65b05a5e2976065a13cc177686c12b0ee78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->